### PR TITLE
[POC] Resource Permissions with support for Views

### DIFF
--- a/src/integrationTest/java/org/opensearch/security/http/ViewsTests.java
+++ b/src/integrationTest/java/org/opensearch/security/http/ViewsTests.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.security.http;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.runner.RunWith;
+
+import org.opensearch.client.Client;
+import org.opensearch.test.framework.RolesMapping;
+import org.opensearch.test.framework.TestSecurityConfig;
+import org.opensearch.test.framework.cluster.LocalCluster;
+import org.opensearch.test.framework.cluster.TestRestClient;
+import org.opensearch.test.framework.cluster.TestRestClient.HttpResponse;
+
+import static org.apache.http.HttpStatus.SC_CREATED;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.opensearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
+import static org.opensearch.security.Song.SONGS;
+import static org.opensearch.test.framework.TestSecurityConfig.AuthcDomain.AUTHC_HTTPBASIC_INTERNAL;
+import static org.opensearch.test.framework.TestSecurityConfig.Role.ALL_ACCESS;
+
+@RunWith(com.carrotsearch.randomizedtesting.RandomizedRunner.class)
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
+public class ViewsTests {
+    private static final TestSecurityConfig.User ADMIN_USER = new TestSecurityConfig.User("admin").backendRoles("admin");
+    private static final TestSecurityConfig.User VIEW_USER = new TestSecurityConfig.User("view_user");
+
+    @ClassRule
+    public static LocalCluster cluster = new LocalCluster.Builder().singleNode()
+        .authc(AUTHC_HTTPBASIC_INTERNAL)
+        .users(ADMIN_USER, VIEW_USER)
+        .rolesMapping(new RolesMapping(ALL_ACCESS).backendRoles("admin"))
+        .build();
+
+    @BeforeClass
+    public static void createTestData() {
+        try (final Client client = cluster.getInternalNodeClient()) {
+            client.prepareIndex("songs-2022").setRefreshPolicy(IMMEDIATE).setSource(SONGS[0].asMap()).get();
+            client.prepareIndex("songs-2023").setRefreshPolicy(IMMEDIATE).setSource(SONGS[1].asMap()).get();
+        }
+    }
+
+    public void createView() {
+        try (
+            final TestRestClient adminClient = cluster.getRestClient(ADMIN_USER);
+            final TestRestClient viewClient = cluster.getRestClient(VIEW_USER)
+        ) {
+
+            final HttpResponse getAllViews = adminClient.get("/views");
+            assertThat("No views have been created yet", getAllViews.getIntFromJsonBody("/views/count"), equalTo(0));
+
+            final HttpResponse createView = adminClient.postJson("/views", createViewBody());
+            createView.assertStatusCode(SC_CREATED);
+
+            final HttpResponse searchView = adminClient.postJson("/views/songs/_search", createQueryString());
+            assertThat(searchView.getIntFromJsonBody("/hits/total/value"), equalTo("2"));
+        }
+    }
+
+    private String createQueryString() {
+        return "{\n"
+            + "    \"query\": {\n"
+            + "        \"match_all\": {}\n"
+            + "    },\n"
+            + "    \"sort\": {\n"
+            + "        \"title\": {\n"
+            + "            \"order\": \"asc\"\n"
+            + "        }\n"
+            + "    }\n"
+            + "}";
+    }
+
+    private String createViewBody() {
+        return "{\n"
+            + "    \"name\": \"songs\",\n"
+            + "    \"description\": \"like imdb but smaller for songs\",\n"
+            + "    \"targets\": [\n"
+            + "        {\n"
+            + "            \"indexPattern\": \"songs-2023, songs-2022\"\n"
+            + "        }\n"
+            + "    ]\n"
+            + "}";
+    }
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/TestSecurityConfig.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/TestSecurityConfig.java
@@ -342,6 +342,7 @@ public class TestSecurityConfig {
         private List<String> clusterPermissions = new ArrayList<>();
 
         private List<IndexPermission> indexPermissions = new ArrayList<>();
+        private List<String, User> resourcePermissions;
 
         public Role(String name) {
             this.name = name;
@@ -382,6 +383,10 @@ public class TestSecurityConfig {
 
             if (!indexPermissions.isEmpty()) {
                 xContentBuilder.field("index_permissions", indexPermissions);
+            }
+
+            if (!resourcePermissions.isEmpty()) {
+                xContentBuilder.field("resource_permissions", resourcePermissions);
             }
 
             xContentBuilder.endObject();

--- a/src/integrationTest/java/org/opensearch/test/framework/TestSecurityConfig.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/TestSecurityConfig.java
@@ -336,13 +336,13 @@ public class TestSecurityConfig {
     }
 
     public static class Role implements ToXContentObject {
-        public static Role ALL_ACCESS = new Role("all_access").clusterPermissions("*").indexPermissions("*").on("*");
+        public static Role ALL_ACCESS = new Role("all_access").clusterPermissions("*").indexPermissions("*").on("*").resourcePermissions("*", "*");
 
         private String name;
         private List<String> clusterPermissions = new ArrayList<>();
 
         private List<IndexPermission> indexPermissions = new ArrayList<>();
-        private List<String, User> resourcePermissions;
+        private List<ResourcePermission> resourcePermissions = new ArrayList<>();
 
         public Role(String name) {
             this.name = name;
@@ -355,6 +355,11 @@ public class TestSecurityConfig {
 
         public IndexPermission indexPermissions(String... indexPermissions) {
             return new IndexPermission(this, indexPermissions);
+        }
+
+        public Role resourcePermissions(final String resourceType, final String... resourceIds) {
+            resourcePermissions.add(new ResourcePermission(resourceType).resourceIds(resourceIds));
+            return this;
         }
 
         public Role name(String name) {
@@ -370,6 +375,7 @@ public class TestSecurityConfig {
             Role role = new Role(this.name);
             role.clusterPermissions.addAll(this.clusterPermissions);
             role.indexPermissions.addAll(this.indexPermissions);
+            role.resourcePermissions.addAll(this.resourcePermissions);
             return role;
         }
 
@@ -452,6 +458,31 @@ public class TestSecurityConfig {
             if (maskedFields != null) {
                 xContentBuilder.field("masked_fields", maskedFields);
             }
+
+            xContentBuilder.endObject();
+            return xContentBuilder;
+        }
+    }
+
+    public static class ResourcePermission implements ToXContentObject {
+        private String resourceType;
+        private List<String> resourceIds;
+
+        ResourcePermission(final String resourceType) {
+            this.resourceType = resourceType;
+        }
+
+        public ResourcePermission resourceIds(final String... resourceIds) {
+            this.resourceIds = Arrays.asList(resourceIds);
+            return this;
+        }
+
+        @Override
+        public XContentBuilder toXContent(final XContentBuilder xContentBuilder, final Params params) throws IOException {
+            xContentBuilder.startObject();
+
+            xContentBuilder.field("resource_type", resourceType);
+            xContentBuilder.field("resource_ids", resourceIds);
 
             xContentBuilder.endObject();
             return xContentBuilder;

--- a/src/integrationTest/resources/log4j2-test.properties
+++ b/src/integrationTest/resources/log4j2-test.properties
@@ -45,3 +45,8 @@ logger.ldap.name=com.amazon.dlic.auth.ldap.backend
 logger.ldap.level=TRACE
 logger.backendreg.additivity = false
 logger.ldap.appenderRef.capturing.ref = logCapturingAppender
+
+logger.pe.name = org.opensearch.security.privileges
+logger.pe.level=DEBUG
+logger.backendreg.additivity = true
+logger.pe.appenderRef.capturing.ref = logCapturingAppender

--- a/src/main/java/org/opensearch/security/securityconf/ConfigModelV6.java
+++ b/src/main/java/org/opensearch/security/securityconf/ConfigModelV6.java
@@ -542,6 +542,12 @@ public class ConfigModelV6 extends ConfigModel {
             roles.stream().forEach(p -> ipatterns.addAll(p.getIpatterns()));
             return ConfigModelV6.impliesTypePerm(ipatterns, resolved, user, actions, resolver, cs);
         }
+
+        @Override
+        public boolean hasResourcePermission(String resourceType, String resourceId) {
+            /** Not supported */
+            return false;
+        }
     }
 
     public static class SecurityRole {

--- a/src/main/java/org/opensearch/security/securityconf/ConfigModelV7.java
+++ b/src/main/java/org/opensearch/security/securityconf/ConfigModelV7.java
@@ -563,12 +563,24 @@ public class ConfigModelV7 extends ConfigModel {
 
             return false;
         }
+
+        @Override
+        public boolean hasResourcePermission(final String resourceType, final String resourceId) {
+            for (SecurityRole role : roles) {
+                final ResourcePermission resourcePermission = role.resourcePermissions.get(resourceType);
+                if (resourcePermission != null && resourcePermission.permmittedResourceIds.contains(resourceId)) {
+                    return true;
+                }
+            }
+            return false;
+        }
     }
 
     public static class SecurityRole {
         private final String name;
         private final Set<IndexPattern> ipatterns;
         private final WildcardMatcher clusterPerms;
+        private final Map<String, ResourcePermission> resourcePermissions; 
 
         public static final class Builder {
             private final String name;
@@ -600,6 +612,7 @@ public class ConfigModelV7 extends ConfigModel {
             this.name = Objects.requireNonNull(name);
             this.ipatterns = ipatterns;
             this.clusterPerms = clusterPerms;
+            this.resourcePermissions = new HashMap<String, ResourcePermission>();
         }
 
         private boolean impliesClusterPermission(String action) {
@@ -719,6 +732,15 @@ public class ConfigModelV7 extends ConfigModel {
             return name;
         }
 
+    }
+
+    public static class ResourcePermission {
+        private final String resourceType;
+        private final Set<String> permmittedResourceIds;
+        public ResourcePermission(final String resourceType, final List<String> resourceIds) {
+            this.resourceType = resourceType;
+            this.permmittedResourceIds = new HashSet<>(resourceIds); 
+        }
     }
 
     // sg roles

--- a/src/main/java/org/opensearch/security/securityconf/SecurityRoles.java
+++ b/src/main/java/org/opensearch/security/securityconf/SecurityRoles.java
@@ -97,5 +97,5 @@ public interface SecurityRoles {
 
     SecurityRoles filter(Set<String> roles);
 
-    boolean hasResourcePermission(final String resourceType, final String resourceId)
+    boolean hasResourcePermission(final String resourceType, final String resourceId);
 }

--- a/src/main/java/org/opensearch/security/securityconf/SecurityRoles.java
+++ b/src/main/java/org/opensearch/security/securityconf/SecurityRoles.java
@@ -96,4 +96,6 @@ public interface SecurityRoles {
     );
 
     SecurityRoles filter(Set<String> roles);
+
+    boolean hasResourcePermission(final String resourceType, final String resourceId)
 }

--- a/src/main/java/org/opensearch/security/securityconf/impl/v7/RoleV7.java
+++ b/src/main/java/org/opensearch/security/securityconf/impl/v7/RoleV7.java
@@ -227,17 +227,25 @@ public class RoleV7 implements Hideable, StaticDefinable {
     }
 
     public static class ResourcePermission {
-        private String resourceType;
+        private String resource_type;
         private List<String> resource_ids = Collections.emptyList();
 
         public ResourcePermission() {
+        }
+
+        public String getResource_type() {
+            return resource_type;
+        }
+
+        public void setResource_type(final String resource_type) {
+            this.resource_type = resource_type;
         }
 
         public List<String> getResource_ids() {
             return resource_ids;
         }
 
-        public void setResource_ids(List<String> resource_ids) {
+        public void setResource_ids(final List<String> resource_ids) {
             this.resource_ids = resource_ids;
         }
     }
@@ -272,6 +280,14 @@ public class RoleV7 implements Hideable, StaticDefinable {
 
     public void setIndex_permissions(List<Index> index_permissions) {
         this.index_permissions = index_permissions;
+    }
+
+    public List<ResourcePermission> getResource_permissions() {
+        return resource_permissions;
+    }
+
+    public void setResource_permissions(final List<ResourcePermission> resources_permissions) {
+        this.resource_permissions = resources_permissions;
     }
 
     public List<Tenant> getTenant_permissions() {

--- a/src/main/java/org/opensearch/security/securityconf/impl/v7/RoleV7.java
+++ b/src/main/java/org/opensearch/security/securityconf/impl/v7/RoleV7.java
@@ -51,6 +51,7 @@ public class RoleV7 implements Hideable, StaticDefinable {
     private List<String> cluster_permissions = Collections.emptyList();
     private List<Index> index_permissions = Collections.emptyList();
     private List<Tenant> tenant_permissions = Collections.emptyList();
+    private List<ResourcePermission> resource_permissions = Collections.emptyList();
 
     public RoleV7() {
 
@@ -225,6 +226,22 @@ public class RoleV7 implements Hideable, StaticDefinable {
 
     }
 
+    public static class ResourcePermission {
+        private String resourceType;
+        private List<String> resource_ids = Collections.emptyList();
+
+        public ResourcePermission() {
+        }
+
+        public List<String> getResource_ids() {
+            return resource_ids;
+        }
+
+        public void setResource_ids(List<String> resource_ids) {
+            this.resource_ids = resource_ids;
+        }
+    }
+
     public boolean isHidden() {
         return hidden;
     }
@@ -299,6 +316,8 @@ public class RoleV7 implements Hideable, StaticDefinable {
             + index_permissions
             + ", tenant_permissions="
             + tenant_permissions
+            + ", resource_permissions="
+            + resource_permissions
             + "]";
     }
 

--- a/src/main/resources/static_config/static_roles.yml
+++ b/src/main/resources/static_config/static_roles.yml
@@ -20,6 +20,9 @@ all_access:
         - "*"
       allowed_actions:
         - "kibana_all_write"
+  resource_permissions:
+    - resource_type: "*"
+      resource_ids: ["*"]
 
 kibana_user:
   reserved: true


### PR DESCRIPTION
### Description
For the views feature resource permissioned are needed to authorization requests, this is a proof of concept for how those could be defined with viable test case.

### Issues Resolved
- Related https://github.com/peternied/OpenSearch-1/pull/139
- Related https://github.com/opensearch-project/security/issues/3873

### Testing
- Build companion OpenSearch change `./gradlew server:publishToMavenLocal -x server:javadoc`
- Build & run security plugin test `./gradlew integrationTest --tests org.opensearch.security.http.ViewsTests -x jacocoReport `